### PR TITLE
add a method to read the orientation in euler angles

### DIFF
--- a/lib/bno055.ex
+++ b/lib/bno055.ex
@@ -6,12 +6,21 @@ defmodule BNO055 do
   alias Circuits.I2C
   alias BNO055.Registers.OprMode
   @addr 40
+  @heading_register 0x1A
 
   defstruct [:i2c, :opts]
 
   def setup(mode, opts \\ []) do
     {:ok, ref} = I2C.open(Keyword.get(opts, :i2c_device, "i2c-1"))
-    :ok = I2C.write(ref, @addr, <<OprMode.addr(), OprMode.encode(mode)>>)
+    :ok = I2C.write(ref, @addr, [OprMode.addr(), OprMode.encode(mode)])
     %__MODULE__{i2c: ref, opts: opts}
+  end
+
+  def orientation(%__MODULE__{i2c: ref}) do
+    case I2C.write_read(ref, @addr, <<@heading_register>>, 6) do
+      {:ok, <<heading :: little-signed-size(16), roll :: little-signed-size(16), pitch :: little-signed-size(16)>> } ->
+        {:ok, heading, roll, pitch}
+      _anything_else -> :error
+    end
   end
 end

--- a/lib/bno055/registers/opr_mode.ex
+++ b/lib/bno055/registers/opr_mode.ex
@@ -1,5 +1,5 @@
 defmodule BNO055.Registers.OprMode do
-  def addr, do: 0x3D
+  def addr, do: <<0x3D>>
 
   def encode(:CONFIGMODE), do: <<0>>
   def encode(:ACCONLY), do: <<1>>


### PR DESCRIPTION
This PR fixes the OprMode register address to be binary and also adds a helper function for reading the orientation of the chip in Euler angles.